### PR TITLE
separate evaluate and upload test data

### DIFF
--- a/drucker/drucker_dashboard_servicer.py
+++ b/drucker/drucker_dashboard_servicer.py
@@ -182,9 +182,7 @@ class DruckerDashboardServicer(drucker_pb2_grpc.DruckerDashboardServicer):
         if not self.is_valid_upload_filename(result_path):
             raise Exception(f'Error: Invalid evaluation result file path specified -> {result_path}')
 
-        eval_data = self.app.parse_eval_data(self.app.get_eval_path(data_path))
-
-        result, details = self.app.evaluate(eval_data)
+        result, details = self.app.evaluate(self.app.get_eval_path(data_path))
         metrics = drucker_pb2.EvaluationMetrics(num=result.num,
                                                 accuracy=result.accuracy,
                                                 precision=result.precision,

--- a/drucker/drucker_worker.py
+++ b/drucker/drucker_worker.py
@@ -4,10 +4,12 @@
 
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from typing import List, Tuple
+from typing import List, Tuple, Generator, Iterator
 from sqlalchemy.sql import exists
+import io
+import csv
 
-from .utils import DruckerConfig, PredictLabel, PredictResult, EvaluateResult, EvaluateDetail
+from .utils import DruckerConfig, PredictLabel, PredictResult, EvaluateResult, EvaluateDetail, EvaluateData
 from .logger import logger
 from .models import db, ModelAssignment
 
@@ -73,6 +75,12 @@ class Drucker(metaclass=ABCMeta):
         return self.__type_output
 
     @abstractmethod
+    def parse_eval_data(self, file_path: str) -> Generator[EvaluateData, None, None]:
+        """parse file uploaded from dashboard
+        """
+        raise NotImplemented()
+
+    @abstractmethod
     def load_model(self) -> None:
         raise NotImplemented()
 
@@ -81,5 +89,5 @@ class Drucker(metaclass=ABCMeta):
         raise NotImplemented()
 
     @abstractmethod
-    def evaluate(self, file: bytes) -> Tuple[EvaluateResult, List[EvaluateDetail]]:
+    def evaluate(self, eval_data: Iterator[EvaluateData]) -> Tuple[EvaluateResult, List[EvaluateDetail]]:
         raise NotImplemented()

--- a/drucker/drucker_worker.py
+++ b/drucker/drucker_worker.py
@@ -4,12 +4,10 @@
 
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from typing import List, Tuple, Generator, Iterator
+from typing import List, Tuple
 from sqlalchemy.sql import exists
-import io
-import csv
 
-from .utils import DruckerConfig, PredictLabel, PredictResult, EvaluateResult, EvaluateDetail, EvaluateData
+from .utils import DruckerConfig, PredictLabel, PredictResult, EvaluateResult, EvaluateDetail
 from .logger import logger
 from .models import db, ModelAssignment
 
@@ -75,12 +73,6 @@ class Drucker(metaclass=ABCMeta):
         return self.__type_output
 
     @abstractmethod
-    def parse_eval_data(self, file_path: str) -> Generator[EvaluateData, None, None]:
-        """parse file uploaded from dashboard
-        """
-        raise NotImplemented()
-
-    @abstractmethod
     def load_model(self) -> None:
         raise NotImplemented()
 
@@ -89,5 +81,5 @@ class Drucker(metaclass=ABCMeta):
         raise NotImplemented()
 
     @abstractmethod
-    def evaluate(self, eval_data: Iterator[EvaluateData]) -> Tuple[EvaluateResult, List[EvaluateDetail]]:
+    def evaluate(self, file_path: str) -> Tuple[EvaluateResult, List[EvaluateDetail]]:
         raise NotImplemented()

--- a/drucker/test/dummy_app.py
+++ b/drucker/test/dummy_app.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from typing import List, Tuple, Iterator, Generator
+from typing import List, Tuple
 
 from drucker import Drucker
-from drucker.utils import PredictLabel, PredictResult, EvaluateResult, EvaluateDetail, EvaluateData
+from drucker.utils import PredictLabel, PredictResult, EvaluateResult, EvaluateDetail
 
 
 class DummyApp(Drucker):
@@ -17,8 +17,5 @@ class DummyApp(Drucker):
     def predict(self, input: PredictLabel, option: dict = None) -> PredictResult:
         pass
 
-    def evaluate(self, eva_data: Iterator[EvaluateData]) -> Tuple[EvaluateResult, List[EvaluateDetail]]:
-        pass
-
-    def parse_eval_data(self, file_path: str) -> Generator[EvaluateData, None, None]:
+    def evaluate(self, file_path: str) -> Tuple[EvaluateResult, List[EvaluateDetail]]:
         pass

--- a/drucker/test/dummy_app.py
+++ b/drucker/test/dummy_app.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from typing import List, Tuple
+from typing import List, Tuple, Iterator, Generator
 
 from drucker import Drucker
-from drucker.utils import PredictLabel, PredictResult, EvaluateResult, EvaluateDetail
+from drucker.utils import PredictLabel, PredictResult, EvaluateResult, EvaluateDetail, EvaluateData
 
 
 class DummyApp(Drucker):
@@ -17,5 +17,8 @@ class DummyApp(Drucker):
     def predict(self, input: PredictLabel, option: dict = None) -> PredictResult:
         pass
 
-    def evaluate(self, file: bytes) -> Tuple[EvaluateResult, List[EvaluateDetail]]:
+    def evaluate(self, eva_data: Iterator[EvaluateData]) -> Tuple[EvaluateResult, List[EvaluateDetail]]:
+        pass
+
+    def parse_eval_data(self, file_path: str) -> Generator[EvaluateData, None, None]:
         pass

--- a/drucker/test/test_dashboard_servicer.py
+++ b/drucker/test/test_dashboard_servicer.py
@@ -1,13 +1,13 @@
 import unittest
 import time
 from functools import wraps
-from unittest.mock import patch, Mock, mock_open, call
+from unittest.mock import patch, Mock, mock_open
 import grpc_testing
 from grpc import StatusCode
 
 from drucker.protobuf import drucker_pb2
 from drucker.drucker_dashboard_servicer import DruckerDashboardServicer
-from drucker.utils import EvaluateResult, EvaluateDetail, PredictResult, EvaluateData
+from drucker.utils import EvaluateResult, EvaluateDetail, PredictResult
 from . import app, system_logger
 
 
@@ -47,7 +47,6 @@ class DruckerWorkerServicerTest(unittest.TestCase):
         app.get_eval_path = Mock(return_value='test/my_eval_path')
         app.config.SERVICE_INFRA = 'default'
         app.evaluate = Mock(return_value=(eval_result, details))
-        app.parse_eval_data = Mock(return_value=[EvaluateData('my_input', 'my_label')])
         self._real_time = grpc_testing.strict_real_time()
         self._fake_time = grpc_testing.strict_fake_time(time.time())
         servicer = DruckerDashboardServicer(logger=system_logger, app=app)

--- a/drucker/utils/__init__.py
+++ b/drucker/utils/__init__.py
@@ -9,7 +9,6 @@ from enum import Enum
 from typing import Union, List, Dict, NamedTuple
 
 
-PredictInput = Union[str, bytes, List[str], List[int], List[float]]
 PredictLabel = Union[str, bytes, List[str], List[int], List[float]]
 PredictScore = Union[float, List[float]]
 
@@ -91,11 +90,6 @@ class EvaluateResult:
 class EvaluateDetail(NamedTuple):
     result: PredictResult
     is_correct: bool
-
-
-class EvaluateData(NamedTuple):
-    input: PredictInput
-    label: PredictLabel
 
 
 incoming_headers = [

--- a/drucker/utils/__init__.py
+++ b/drucker/utils/__init__.py
@@ -89,7 +89,10 @@ class EvaluateResult:
 
 
 class EvaluateDetail(NamedTuple):
-    input: PredictInput
-    label: PredictLabel
     result: PredictResult
     is_correct: bool
+
+
+class EvaluateData(NamedTuple):
+    input: PredictInput
+    label: PredictLabel


### PR DESCRIPTION
## What is this PR for?

Not to upload the same evaluation data, separate evaluate and upload test data

## This PR includes

- update grpc commit to https://github.com/rekcurd/drucker-grpc-proto/pull/12
- implement UploadEvaluationData based on https://github.com/rekcurd/drucker-grpc-proto/pull/12
- fix EvaluateModel based on https://github.com/rekcurd/drucker-grpc-proto/pull/12
- add `parse_eval_data` method to Drucker class. (parse file byte data to `EvaluateData` class)
- remove evaluation data (input and label) from `EvaluateDetail` class

## What type of PR is it?

Feature

## What is the issue?

N/A

## How should this be tested?

python -m unittest
