### PR TITLE
[Hotfix] fix ServiceEnvType if statement and make check strict

### DIFF
--- a/drucker/utils/__init__.py
+++ b/drucker/utils/__init__.py
@@ -55,10 +55,10 @@ class ServiceEnvType(Enum):
             return cls.STAGING
         elif cls.SANDBOX.value == istr:
             return cls.SANDBOX
-        elif cls.PRODUCTION == istr:
+        elif cls.PRODUCTION.value == istr:
             return cls.PRODUCTION
         else:
-            return None
+            raise ValueError("'{}' is not supported as ServiceEnvType".format(istr))
 
 
 class PredictResult:


### PR DESCRIPTION
## What is this PR for?

Hotfix for ServiceEnvType initialization

## This PR includes

- fix ServiceEnvType
- raise ValueError with non-supported strings.
    - When I was stuck with the problem, output log did not tell me what string is passed to ServiceEnvType, so I clarified by raising Exception.

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

run test with `app.service.level` `production`
