### PR TITLE
implement method for EvaluationResult protocol

### DIFF
--- a/drucker/drucker_dashboard_servicer.py
+++ b/drucker/drucker_dashboard_servicer.py
@@ -254,7 +254,7 @@ class DruckerDashboardServicer(drucker_pb2_grpc.DruckerDashboardServicer):
         detail_chunks = []
         detail_chunk = []
         metrics_size = sys.getsizeof(metrics)
-        for detail in self.app.get_evaluate_data(self.app.get_eval_path(data_path), result_details):
+        for detail in self.app.get_evaluate_detail(self.app.get_eval_path(data_path), result_details):
             detail_chunk.append(drucker_pb2.EvaluationResultResponse.Detail(
                 input=self.get_io_by_type(detail.input),
                 label=self.get_io_by_type(detail.label),

--- a/drucker/drucker_dashboard_servicer.py
+++ b/drucker/drucker_dashboard_servicer.py
@@ -8,14 +8,16 @@ import types
 import shutil
 import uuid
 import pickle
+import sys
 from pathlib import Path
 
 from grpc import ServicerContext
-from typing import Iterator
+from typing import Iterator, Union, List
 
 from .logger import SystemLoggerInterface
 from .drucker_worker import Drucker, db, ModelAssignment
 from .protobuf import drucker_pb2, drucker_pb2_grpc
+from .utils import PredictInput, PredictLabel, PredictScore
 
 
 def error_handling(error_response):
@@ -167,7 +169,7 @@ class DruckerDashboardServicer(drucker_pb2_grpc.DruckerDashboardServicer):
         return drucker_pb2.ModelResponse(status=1,
                                          message='Success: Switching model file.')
 
-    @error_handling(drucker_pb2.EvaluateModelResponse(metrics=drucker_pb2.EvaluationMetrics()))
+    @error_handling(drucker_pb2.EvaluateModelResponse())
     def EvaluateModel(self,
                       request_iterator: Iterator[drucker_pb2.EvaluateModelRequest],
                       context: ServicerContext
@@ -219,3 +221,77 @@ class DruckerDashboardServicer(drucker_pb2_grpc.DruckerDashboardServicer):
 
         return drucker_pb2.UploadEvaluationDataResponse(status=1,
                                                         message='Success: Uploading evaluation data.')
+
+    @error_handling(drucker_pb2.EvaluationResultResponse())
+    def EvaluationResult(self,
+                         request: drucker_pb2.EvaluationResultRequest,
+                         context: ServicerContext
+                         ) -> Iterator[drucker_pb2.EvaluationResultResponse]:
+        """ Return saved evaluation result
+        """
+        data_path = request.data_path
+        result_path = request.result_path
+        if not self.is_valid_upload_filename(data_path):
+            raise Exception(f'Error: Invalid evaluation file path specified -> {data_path}')
+        if not self.is_valid_upload_filename(result_path):
+            raise Exception(f'Error: Invalid evaluation result file path specified -> {result_path}')
+
+        eval_result_path = self.app.get_eval_path(result_path)
+        with open(eval_result_path + self.EVALUATE_DETAIL, 'rb') as f:
+            result_details = pickle.load(f)
+        with open(eval_result_path + self.EVALUATE_RESULT, 'rb') as f:
+            result = pickle.load(f)
+        metrics = drucker_pb2.EvaluationMetrics(num=result.num,
+                                                accuracy=result.accuracy,
+                                                precision=result.precision,
+                                                recall=result.recall,
+                                                fvalue=result.fvalue,
+                                                option=result.option)
+
+        DETAIL_UNIT_SIZE = 100
+        BYTE_LIMIT = 4190000
+        detail_chunks = []
+        detail_chunk = []
+        metrics_size = sys.getsizeof(metrics)
+
+        for detail in self.app.get_evaluate_data(self.app.get_eval_path(data_path), result_details):
+            detail_chunk.append(drucker_pb2.EvaluationResultResponse.Detail(
+                input=self.get_io_by_type(detail.input),
+                label=self.get_io_by_type(detail.label),
+                output=self.get_io_by_type(detail.result.result.label),
+                score=self.get_score_by_type(detail.result.result.score),
+                is_correct=detail.result.is_correct
+            ))
+            if len(detail_chunk) == DETAIL_UNIT_SIZE:
+                if metrics_size + sys.getsizeof(detail_chunk + detail_chunks) < BYTE_LIMIT:
+                    detail_chunks.extend(detail_chunk)
+                else:
+                    yield drucker_pb2.EvaluationResultResponse(metrics=metrics, detail=detail_chunks)
+                    detail_chunks = detail_chunk
+                detail_chunk = []
+
+        if len(detail_chunks + detail_chunk) > 0:
+            if metrics_size + sys.getsizeof(detail_chunk + detail_chunks) < BYTE_LIMIT:
+                detail_chunks.extend(detail_chunk)
+                yield drucker_pb2.EvaluationResultResponse(metrics=metrics, detail=detail_chunks)
+            else:
+                yield drucker_pb2.EvaluationResultResponse(metrics=metrics, detail=detail_chunks)
+                yield drucker_pb2.EvaluationResultResponse(metrics=metrics, detail=detail_chunk)
+
+    def get_io_by_type(self, io: Union[PredictInput, PredictLabel]) -> drucker_pb2.IO:
+        if not isinstance(io, list):
+            io = [io]
+
+        if len(io) == 0:
+            return drucker_pb2.IO(tensor=drucker_pb2.Tensor())
+        if isinstance(io[0], str):
+            return drucker_pb2.IO(str=drucker_pb2.ArrString(val=io))
+        else:
+            return drucker_pb2.IO(tensor=drucker_pb2.Tensor(shape=[1], val=io))
+
+    def get_score_by_type(self, score: PredictScore) -> List[float]:
+        if isinstance(score, list):
+            return score
+        else:
+            return [score]
+

--- a/drucker/drucker_worker.py
+++ b/drucker/drucker_worker.py
@@ -85,5 +85,5 @@ class Drucker(metaclass=ABCMeta):
         raise NotImplemented()
 
     @abstractmethod
-    def get_evaluate_data(self, file_path: str, results: List[EvaluateResultDetail]) -> Generator[EvaluateDetail, None, None]:
+    def get_evaluate_detail(self, file_path: str, results: List[EvaluateResultDetail]) -> Generator[EvaluateDetail, None, None]:
         raise NotImplemented()

--- a/drucker/drucker_worker.py
+++ b/drucker/drucker_worker.py
@@ -4,10 +4,10 @@
 
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from typing import List, Tuple
+from typing import List, Tuple, Generator
 from sqlalchemy.sql import exists
 
-from .utils import DruckerConfig, PredictLabel, PredictResult, EvaluateResult, EvaluateDetail
+from .utils import DruckerConfig, PredictLabel, PredictResult, EvaluateResult, EvaluateDetail, EvaluateResultDetail
 from .logger import logger
 from .models import db, ModelAssignment
 
@@ -81,5 +81,9 @@ class Drucker(metaclass=ABCMeta):
         raise NotImplemented()
 
     @abstractmethod
-    def evaluate(self, file_path: str) -> Tuple[EvaluateResult, List[EvaluateDetail]]:
+    def evaluate(self, file_path: str) -> Tuple[EvaluateResult, List[EvaluateResultDetail]]:
+        raise NotImplemented()
+
+    @abstractmethod
+    def get_evaluate_data(self, file_path: str, results: List[EvaluateResultDetail]) -> Generator[EvaluateDetail, None, None]:
         raise NotImplemented()

--- a/drucker/test/dummy_app.py
+++ b/drucker/test/dummy_app.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from typing import List, Tuple
+from typing import List, Tuple, Generator
 
 from drucker import Drucker
-from drucker.utils import PredictLabel, PredictResult, EvaluateResult, EvaluateDetail
+from drucker.utils import PredictLabel, PredictResult, EvaluateResult, EvaluateDetail, EvaluateResultDetail
 
 
 class DummyApp(Drucker):
@@ -17,5 +17,8 @@ class DummyApp(Drucker):
     def predict(self, input: PredictLabel, option: dict = None) -> PredictResult:
         pass
 
-    def evaluate(self, file_path: str) -> Tuple[EvaluateResult, List[EvaluateDetail]]:
+    def evaluate(self, file_path: str) -> Tuple[EvaluateResult, List[EvaluateResultDetail]]:
+        pass
+
+    def get_evaluate_data(self, file_path: str, results: List[EvaluateResultDetail]) -> Generator[EvaluateDetail, None, None]:
         pass

--- a/drucker/test/dummy_app.py
+++ b/drucker/test/dummy_app.py
@@ -20,5 +20,5 @@ class DummyApp(Drucker):
     def evaluate(self, file_path: str) -> Tuple[EvaluateResult, List[EvaluateResultDetail]]:
         pass
 
-    def get_evaluate_data(self, file_path: str, results: List[EvaluateResultDetail]) -> Generator[EvaluateDetail, None, None]:
+    def get_evaluate_detail(self, file_path: str, results: List[EvaluateResultDetail]) -> Generator[EvaluateDetail, None, None]:
         pass

--- a/drucker/test/test_dashboard_servicer.py
+++ b/drucker/test/test_dashboard_servicer.py
@@ -17,7 +17,7 @@ eval_result = EvaluateResult(1, 0.8, [0.7], [0.6], [0.5], {'dummy': 0.4})
 eval_result_details = [EvaluateResultDetail(PredictResult('pre_label', 0.9), False)]
 eval_detail = EvaluateDetail('input', 'label', eval_result_details[0])
 
-# Overwrite CHUNK_SIZE and BYTE_LIMIT to smaller values for tesging
+# Overwrite CHUNK_SIZE and BYTE_LIMIT to smaller values for testing
 chunk_size = 3
 DruckerDashboardServicer.CHUNK_SIZE = chunk_size
 # response byte size will be greater than BYTE_LIMIT in 2nd loop

--- a/drucker/test/test_dashboard_servicer.py
+++ b/drucker/test/test_dashboard_servicer.py
@@ -62,7 +62,6 @@ class DruckerWorkerServicerTest(unittest.TestCase):
         rpc = self._real_time_server.invoke_unary_unary(
             target_service.methods_by_name['ServiceInfo'], (),
             drucker_pb2.ServiceInfoRequest(), None)
-        initial_metadata = rpc.initial_metadata()
         response, trailing_metadata, code, details = rpc.termination()
         self.assertIs(code, StatusCode.OK)
         self.assertEqual(response.application_name, 'test')
@@ -78,7 +77,6 @@ class DruckerWorkerServicerTest(unittest.TestCase):
         rpc.send_request(request)
         rpc.send_request(request)
         rpc.requests_closed()
-        initial_metadata = rpc.initial_metadata()
         response, trailing_metadata, code, details = rpc.termination()
         self.assertIs(code, StatusCode.OK)
         self.assertEqual(response.status, 1)
@@ -92,7 +90,6 @@ class DruckerWorkerServicerTest(unittest.TestCase):
         rpc.send_request(request)
         rpc.send_request(request)
         rpc.requests_closed()
-        initial_metadata = rpc.initial_metadata()
         response, trailing_metadata, code, details = rpc.termination()
         self.assertIs(code, StatusCode.UNKNOWN)
         self.assertEqual(response.status, 0)
@@ -102,7 +99,6 @@ class DruckerWorkerServicerTest(unittest.TestCase):
         rpc = self._real_time_server.invoke_unary_unary(
             target_service.methods_by_name['SwitchModel'], (),
             drucker_pb2.SwitchModelRequest(path='my_path'), None)
-        initial_metadata = rpc.initial_metadata()
         response, trailing_metadata, code, details = rpc.termination()
         self.assertIs(code, StatusCode.OK)
         self.assertEqual(response.status, 1)
@@ -112,7 +108,6 @@ class DruckerWorkerServicerTest(unittest.TestCase):
         rpc = self._real_time_server.invoke_unary_unary(
             target_service.methods_by_name['SwitchModel'], (),
             drucker_pb2.SwitchModelRequest(path='../../my_path'), None)
-        initial_metadata = rpc.initial_metadata()
         response, trailing_metadata, code, details = rpc.termination()
         self.assertIs(code, StatusCode.UNKNOWN)
         self.assertEqual(response.status, 0)
@@ -150,7 +145,6 @@ class DruckerWorkerServicerTest(unittest.TestCase):
         rpc.send_request(request)
         rpc.send_request(request)
         rpc.requests_closed()
-        initial_metadata = rpc.initial_metadata()
         response, trailing_metadata, code, details = rpc.termination()
         self.assertIs(code, StatusCode.OK)
         self.assertEqual(round(response.metrics.num, 3), eval_result.num)
@@ -167,7 +161,6 @@ class DruckerWorkerServicerTest(unittest.TestCase):
             target_service.methods_by_name['EvaluateModel'], (), None)
         rpc.send_request(request)
         rpc.requests_closed()
-        initial_metadata = rpc.initial_metadata()
         response, trailing_metadata, code, details = rpc.termination()
         self.assertIs(code, StatusCode.UNKNOWN)
         self.assertEqual(response.metrics.num, 0)
@@ -177,7 +170,6 @@ class DruckerWorkerServicerTest(unittest.TestCase):
             target_service.methods_by_name['EvaluateModel'], (), None)
         rpc.send_request(request)
         rpc.requests_closed()
-        initial_metadata = rpc.initial_metadata()
         response, trailing_metadata, code, details = rpc.termination()
         self.assertIs(code, StatusCode.UNKNOWN)
         self.assertEqual(response.metrics.num, 0)

--- a/drucker/test/test_dashboard_servicer.py
+++ b/drucker/test/test_dashboard_servicer.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 import time
 from functools import wraps
 from unittest.mock import patch, Mock, mock_open
@@ -7,13 +8,20 @@ from grpc import StatusCode
 
 from drucker.protobuf import drucker_pb2
 from drucker.drucker_dashboard_servicer import DruckerDashboardServicer
-from drucker.utils import EvaluateResult, EvaluateDetail, PredictResult
+from drucker.utils import EvaluateResult, EvaluateResultDetail, PredictResult, EvaluateDetail
 from . import app, system_logger
 
 
 target_service = drucker_pb2.DESCRIPTOR.services_by_name['DruckerDashboard']
 eval_result = EvaluateResult(1, 0.8, [0.7], [0.6], [0.5], {'dummy': 0.4})
-details = [EvaluateDetail(PredictResult('pre_label', 0.9), False)]
+eval_result_details = [EvaluateResultDetail(PredictResult('pre_label', 0.9), False)]
+eval_detail = EvaluateDetail('input', 'label', eval_result_details[0])
+
+# Overwrite CHUNK_SIZE and BYTE_LIMIT to smaller values for tesging
+chunk_size = 3
+DruckerDashboardServicer.CHUNK_SIZE = chunk_size
+# response byte size will be greater than BYTE_LIMIT in 2nd loop
+DruckerDashboardServicer.BYTE_LIMIT = 190
 
 
 def patch_predictor():
@@ -31,6 +39,8 @@ def patch_predictor():
                         new=Mock(return_value=Mock())) as mock_path, \
                     patch('drucker.drucker_dashboard_servicer.pickle',
                           new=Mock()) as _, \
+                    patch('drucker.drucker_dashboard_servicer.pickle.load',
+                          new=Mock(return_value=eval_result)) as _, \
                     patch('builtins.open', new_callable=mock_open) as _:
                 mock_path.return_value.name = 'my_path'
                 return func(*args, **kwargs)
@@ -46,7 +56,7 @@ class DruckerWorkerServicerTest(unittest.TestCase):
         app.get_model_path = Mock(return_value='test/my_path')
         app.get_eval_path = Mock(return_value='test/my_eval_path')
         app.config.SERVICE_INFRA = 'default'
-        app.evaluate = Mock(return_value=(eval_result, details))
+        app.evaluate = Mock(return_value=(eval_result, eval_result_details))
         self._real_time = grpc_testing.strict_real_time()
         self._fake_time = grpc_testing.strict_fake_time(time.time())
         servicer = DruckerDashboardServicer(logger=system_logger, app=app)
@@ -173,3 +183,68 @@ class DruckerWorkerServicerTest(unittest.TestCase):
         response, trailing_metadata, code, details = rpc.termination()
         self.assertIs(code, StatusCode.UNKNOWN)
         self.assertEqual(response.metrics.num, 0)
+
+    def __send_eval_result(self, size, take_times):
+        app.get_evaluate_data = Mock(return_value=iter(eval_detail for _ in range(size)))
+        rpc = self._real_time_server.invoke_unary_stream(
+            target_service.methods_by_name['EvaluationResult'], (),
+            drucker_pb2.EvaluationResultRequest(data_path='my_path', result_path='my_path'), None)
+        responses = [rpc.take_response() for _ in range(take_times)]
+        return rpc, responses
+
+    @patch_predictor()
+    def test_EvalautionResult(self):
+        rpc, responses = self.__send_eval_result(1, 1)
+        response = responses[0]
+
+        self.assertEqual(round(response.metrics.num, 3), eval_result.num)
+        self.assertEqual(round(response.metrics.accuracy, 3), eval_result.accuracy)
+        self.assertEqual([round(p, 3) for p in response.metrics.precision], eval_result.precision)
+        self.assertEqual([round(r, 3) for r in response.metrics.recall], eval_result.recall)
+        self.assertEqual([round(f, 3) for f in response.metrics.fvalue], eval_result.fvalue)
+        self.assertEqual(round(response.metrics.option['dummy'], 3), eval_result.option['dummy'])
+
+        self.assertEqual(len(response.detail), 1)
+        detail = response.detail[0]
+        self.assertEqual(detail.input.str.val, [eval_detail.input])
+        self.assertEqual(detail.label.str.val, [eval_detail.label])
+        self.assertEqual(detail.output.str.val, [eval_result_details[0].result.label])
+        self.assertEqual([round(s, 3) for s in detail.score], [eval_result_details[0].result.score])
+        self.assertEqual(detail.is_correct, eval_result_details[0].is_correct)
+
+        with self.assertRaises(ValueError):
+            rpc.take_response()
+
+        trailing_metadata, code, details = rpc.termination()
+        self.assertIs(code, StatusCode.OK)
+
+    @patch_predictor()
+    def test_EvalautionResult_multi_response(self):
+        # chunk_size * 3
+        rpc, responses = self.__send_eval_result(chunk_size * 3, 3)
+        for r in responses:
+            self.assertEqual(len(r.detail), chunk_size)
+        with self.assertRaises(ValueError):
+            rpc.take_response()
+        rpc.termination()
+
+        # chunk_size * 2 + 1
+        rpc, responses = self.__send_eval_result(chunk_size * 2 + 1, 2)
+        self.assertEqual(len(responses[0].detail), chunk_size)
+        self.assertEqual(len(responses[1].detail), chunk_size + 1)
+        with self.assertRaises(ValueError):
+            rpc.take_response()
+        rpc.termination()
+
+    def test_get_io_by_type(self):
+        servicer = DruckerDashboardServicer(logger=system_logger, app=app)
+        self.assertEqual(servicer.get_io_by_type('test').str.val, ['test'])
+        self.assertEqual(servicer.get_io_by_type(['test', 'test2']).str.val, ['test', 'test2'])
+        self.assertEqual(servicer.get_io_by_type(2).tensor.val, [2])
+        self.assertEqual(servicer.get_io_by_type([2, 3]).tensor.val, [2, 3])
+
+    def test_get_score_by_type(self):
+        servicer = DruckerDashboardServicer(logger=system_logger, app=app)
+        score = 4.5
+        self.assertEqual(servicer.get_score_by_type(score), [score])
+        self.assertEqual(servicer.get_score_by_type([score]), [score])

--- a/drucker/test/test_dashboard_servicer.py
+++ b/drucker/test/test_dashboard_servicer.py
@@ -185,7 +185,7 @@ class DruckerWorkerServicerTest(unittest.TestCase):
         self.assertEqual(response.metrics.num, 0)
 
     def __send_eval_result(self, size, take_times):
-        app.get_evaluate_data = Mock(return_value=iter(eval_detail for _ in range(size)))
+        app.get_evaluate_detail = Mock(return_value=iter(eval_detail for _ in range(size)))
         rpc = self._real_time_server.invoke_unary_stream(
             target_service.methods_by_name['EvaluationResult'], (),
             drucker_pb2.EvaluationResultRequest(data_path='my_path', result_path='my_path'), None)

--- a/drucker/utils/__init__.py
+++ b/drucker/utils/__init__.py
@@ -9,6 +9,7 @@ from enum import Enum
 from typing import Union, List, Dict, NamedTuple
 
 
+PredictInput = Union[str, bytes, List[str], List[int], List[float]]
 PredictLabel = Union[str, bytes, List[str], List[int], List[float]]
 PredictScore = Union[float, List[float]]
 
@@ -87,9 +88,15 @@ class EvaluateResult:
             self.option = option
 
 
-class EvaluateDetail(NamedTuple):
+class EvaluateResultDetail(NamedTuple):
     result: PredictResult
     is_correct: bool
+
+
+class EvaluateDetail(NamedTuple):
+    input: PredictInput
+    label: PredictLabel
+    result: EvaluateResultDetail
 
 
 incoming_headers = [


### PR DESCRIPTION
## What is this PR for?

add method for EvaluationResult protocol to return detailed evaluation result to a client.
related to https://github.com/rekcurd/drucker-dashboard/pull/55

## This PR includes

- update grpc submodule to https://github.com/rekcurd/drucker-grpc-proto/pull/13
- implement EvaluationResult method
- make data for gRPC in `get_io_by_type` and `get_score_by_type` method
- rename `EvaluateDetail` `EvaluateResultDetail`
- now `EvaluateDetail` include input, label, EvaluateResultDetail
- remove `initial_metadata = rpc.initial_metadata()` because it is never used.

## What type of PR is it?

Feature

## What is the issue?

## How should this be tested?

`python -m unittest`
